### PR TITLE
better errors, path for @import lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,21 +17,7 @@ module.exports = function(file) {
              "(require('lessify'))(css); module.exports = css;";
     }
 
-    function render(callback) {
-      try {
-        less.render(input, {filename: file, paths: [path.dirname(file)]}, function(err, css) {
-          if (err) {
-            callback(err);
-          } else {
-            callback(null, css);
-          }
-        });
-      } catch (error) {
-        callback(error);
-      }
-    }
-
-    render(function (err, css) {
+    less.render(input, {filename: file, paths: [path.dirname(file)]}, function(err, css) {
       if (err) {
         self.emit('error', err);
       } else {


### PR DESCRIPTION
A few things in this:
1. Better error handling, both for throws from `less.render` and errors in the callback.
2. Passing the filename to `less.render` for better errors
3. Passing the file's directory as the path so `@import`'s work
