### PR TITLE
better error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var less = require("less")
 module.exports = function(file, opts) {
   var input = '';
   if (/\.less$/i.test(file) === false) {
-    return through(); 
+    return through();
   } 
 
   function write(data) { input += data; }
@@ -23,7 +23,7 @@ module.exports = function(file, opts) {
 
     less.render(input, lessOpts, function(err, css) {
       if (err) {
-        self.emit('error', err);
+        self.emit('error', new Error(err.message + ': ' + err.filename + '(' + err.line + ')'));
       } else {
         self.queue(jsToLoad(css));
       }

--- a/test/lessify.js
+++ b/test/lessify.js
@@ -53,5 +53,5 @@ test('should throw on invalid less', function(t) {
     , s = lessify('test.less'); 
 
   s.write('.}');
-  t.throws(function() { s.end(); }, Error, 'should throw on invalid less');
+  t.throws(function() { s.end(); }, new RegExp('missing opening `\\{`: test\\.less\\(1\\)'), 'should throw on invalid less');
 });


### PR DESCRIPTION
Noticed that only proper `Error`s are reported to browserify-middleware, and less doesn't return them. Browserify itself only reports the `.message`, so something more descriptive, with a filename and line number would be better.

This patch makes a proper `Error` with a nice message.
