### PR TITLE
Upgrade Less version to 2.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ module.exports = function(file, opts) {
     lessOpts.filename = file;
     lessOpts.paths = [path.dirname(file)];
 
-    less.render(input, lessOpts, function(err, css) {
+    less.render(input, lessOpts, function(err, output) {
       if (err) {
         self.emit('error', new Error(err.message + ': ' + err.filename + '(' + err.line + ')'));
       } else {
-        self.queue(jsToLoad(css));
+        self.queue(jsToLoad(output.css));
       }
       self.queue(null);
     });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "cssify": "^0.6.0",
-    "less": "^1.7.5",
+    "less": "^2.2.0",
     "through": "^2.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Less 2.2.0 provides a slightly different interface: the callback is
given an output object rather than a CSS string, with output.css
containing the CSS string.  To support Less 2.2.0, this commit
updates index.js to expect one of these output objects, and also
updates package.json to specify Less 2.2.0 as a dependency.