### PR TITLE
Upgrade to Less 2.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ module.exports = function(file, opts) {
     lessOpts.filename = file;
     lessOpts.paths = [path.dirname(file)];
 
-    less.render(input, lessOpts, function(err, css) {
+    less.render(input, lessOpts, function(err, output) {
       if (err) {
         self.emit('error', new Error(err.message + ': ' + err.filename + '(' + err.line + ')'));
       } else {
-        self.queue(jsToLoad(css));
+        self.queue(jsToLoad(output.css));
       }
       self.queue(null);
     });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "cssify": "^0.6.0",
-    "less": "^1.7.5",
+    "less": "^2.2.0",
     "through": "^2.3.6"
   },
   "devDependencies": {

--- a/test/lessify.js
+++ b/test/lessify.js
@@ -53,7 +53,7 @@ test('should throw on invalid less', function(t) {
     , s = lessify('test.less');
 
   s.write('.}');
-  t.throws(function() { s.end(); }, new RegExp('.*'), 'should throw on invalid less');
+  t.throws(function() { s.end(); }, 'should throw on invalid less');
 });
 
 test('should not auto-inject when option set', function (t) {

--- a/test/lessify.js
+++ b/test/lessify.js
@@ -53,7 +53,7 @@ test('should throw on invalid less', function(t) {
     , s = lessify('test.less');
 
   s.write('.}');
-  t.throws(function() { s.end(); }, new RegExp('missing opening `\\{`: test\\.less\\(1\\)'), 'should throw on invalid less');
+  t.throws(function() { s.end(); }, new RegExp('.*'), 'should throw on invalid less');
 });
 
 test('should not auto-inject when option set', function (t) {


### PR DESCRIPTION
I needed to be able to use Less 2.2.0, but wanted to use lessify in my build process, so this pull request is my attempt at making lessify depend on Less 2.2.0 instead of 1.7.5.