### PR TITLE
Emit names of imported files

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ module.exports = function(file, opts) {
       } else {
         self.queue(jsToLoad(output.css));
       }
+      output.imports.forEach(function(f) {
+        self.emit('file', f);
+      });
       self.queue(null);
     });
   }


### PR DESCRIPTION
This allows tools like watchify and browserify-incremental to track all
dependencies, so that they can invalidate caches and trigger rebuild.

See how watchify uses this event here:
https://github.com/substack/watchify/blob/master/index.js#L76-L80