### PR TITLE
Lessify should pass 'paths' option to less during bundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(file, opts) {
     }
 
     lessOpts.filename = file;
-    lessOpts.paths = [path.dirname(file)];
+    lessOpts.paths = lessOpts.paths ? lessOpts.paths.concat([path.dirname(file)]) : [path.dirname(file)];
 
     less.render(input, lessOpts, function(err, output) {
       if (err) {


### PR DESCRIPTION
We rely on 'paths' quite a bit, and this small change concats user defined paths with the file paths that lessify passes to less.
